### PR TITLE
[BUD-107] Update: Add typescript for cypress

### DIFF
--- a/cypress/integration/spec.ts
+++ b/cypress/integration/spec.ts
@@ -1,7 +1,7 @@
 describe('Buddy App Test', () => {
   it('shows root component', function() {
     cy.visit('/');
-    cy.dataCy('root')
+    cy.get('span')
       .should('be.visible')
       .and('have.text', 'Buddy App');
   });

--- a/cypress/plugins/cy-ts-preprocessor.js
+++ b/cypress/plugins/cy-ts-preprocessor.js
@@ -1,0 +1,26 @@
+const wp = require('@cypress/webpack-preprocessor');
+
+const webpackOptions = {
+  resolve: {
+    extensions: ['.ts', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: [/node_modules/],
+        use: [
+          {
+            loader: 'ts-loader',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const options = {
+  webpackOptions,
+};
+
+module.exports = wp(options);

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,17 +1,5 @@
-// ***********************************************************
-// This example plugins/index.js can be used to load plugins
-//
-// You can change the location of this file or turn off loading
-// the plugins file with the 'pluginsFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/plugins-guide
-// ***********************************************************
+const cypressTypeScriptPreprocessor = require('./cy-ts-preprocessor');
 
-// This function is called when a project is opened or re-opened (e.g. due to
-// the project's config changing)
-
-module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+module.exports = on => {
+  on('file:preprocessor', cypressTypeScriptPreprocessor);
 };

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "*/*.ts"
+  ],
+  "compilerOptions": {
+    "noEmit": false,
+    "isolatedModules": false,
+    "types": [
+      "cypress"
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -906,6 +906,21 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bahmutov/add-typescript-to-cypress": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@bahmutov/add-typescript-to-cypress/-/add-typescript-to-cypress-2.1.2.tgz",
+      "integrity": "sha512-fOfkDxs+3KAE9PmJOrSW0wqM7ZpGJOObq/qxv2rI9+8h7f8LGcRzKGVthkrl08HFQ/Ij8Le/fawcG7TXBuckDg==",
+      "dev": true,
+      "requires": {
+        "@cypress/webpack-preprocessor": "4.1.0",
+        "am-i-a-dependency": "1.1.2",
+        "chalk": "2.4.2",
+        "debug": "4.1.1",
+        "shelljs": "0.8.3",
+        "terminal-banner": "1.1.0",
+        "ts-loader": "5.4.5"
+      }
+    },
     "@buildit/gravity-particles": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@buildit/gravity-particles/-/gravity-particles-0.3.0.tgz",
@@ -1015,6 +1030,42 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "@cypress/webpack-preprocessor": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-4.1.0.tgz",
+      "integrity": "sha512-LbxsdYVpHGoC2fMOdW0aQvuvVRD7aZx8p8DrP53HISpl7bD1PqLGWKzhHn7cGG24UHycBJrbaEeKEosW29W1dg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.1",
+        "@babel/preset-env": "^7.0.0",
+        "babel-loader": "^8.0.2",
+        "bluebird": "3.5.0",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -1999,6 +2050,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+    },
+    "am-i-a-dependency": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/am-i-a-dependency/-/am-i-a-dependency-1.1.2.tgz",
+      "integrity": "sha1-+dNCIwTW9kL4IeTEB1ZQNfYWfx8=",
+      "dev": true
     },
     "ansi-colors": {
       "version": "3.2.4",
@@ -7194,6 +7251,12 @@
         "default-gateway": "^4.2.0",
         "ipaddr.js": "^1.9.0"
       }
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
     },
     "invariant": {
       "version": "2.2.4",
@@ -12546,6 +12609,15 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -13353,6 +13425,17 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -14174,6 +14257,12 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
+    "terminal-banner": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/terminal-banner/-/terminal-banner-1.1.0.tgz",
+      "integrity": "sha512-A70B8Io5gGOTKQuoqU6LUPLouNd9DvFLgw3cPh6bfrQjdy7HWW1t04VJfQwjTnygTVDX0xremaj1cg3SQaCGyg==",
+      "dev": true
+    },
     "terser": {
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.8.tgz",
@@ -14373,6 +14462,27 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "ts-loader": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.4.5.tgz",
+      "integrity": "sha512-XYsjfnRQCBum9AMRZpk2rTYSVpdZBpZK+kDh0TeT3kxmQNBDVIeUjdPjY5RZry4eIAb8XHc4gYSUiUWPYvzSRw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^1.0.2",
+        "micromatch": "^3.1.4",
+        "semver": "^5.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "ts-pnp": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typescript": "3.6.3"
   },
   "devDependencies": {
+    "@bahmutov/add-typescript-to-cypress": "^2.1.2",
     "@types/react-test-renderer": "^16.9.0",
     "cypress": "^3.4.1",
     "eslint-config-prettier": "^6.3.0",


### PR DESCRIPTION
# [#BUD-107](https://digitalrig.atlassian.net/browse/BUD-107) Feature: Define E2E tools and create at least 1 E2E test as soon as the 1st deliverable is done

## Description

* Add typescript for cypress

## Prerequisites

* run `npm run start` to start project on http://localhost:3000
* run `npm run cy:open` - it should open Cypress app, then you can navigate and choose a test to run
* `npm run cy:run` - runs tests headlessly in the Electron browser.
* `npm run cy:ci` - starts project on http://localhost:3000 then runs tests headlessly in the Electron browser and close project server.
