### PR TITLE
[BUD-205] Update / Fix Cypress run for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "stable"
 addons:
+  chrome: stable
   apt:
     packages:
     - libgconf-2-4

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "cy:open": "cypress open",
-    "cy:run": "cypress run",
+    "cy:run": "cypress run --browser chrome",
     "cy:ci": "start-server-and-test start http://localhost:3000 cy:run",
     "coverage": "npm test -- --coverage --watchAll=false",
     "prettier": "prettier ./src/**/*.{ts,tsx} --write",


### PR DESCRIPTION
# [#205](https://digitalrig.atlassian.net/browse/BUD-205) Update / Fix Cypress run for CI

## Description

Probaly there's a problem with default Electron browser which is used by default for running cypress test in headless mode. So ther's a need to switch cypress to run tests in chrome stable browser

## Checklist (optional)

- [X] Switch to chrome for cypress headless mode
