### PR TITLE
[BUD-50] Logout

### DIFF
--- a/src/components/UserMenu/UserMenu.tsx
+++ b/src/components/UserMenu/UserMenu.tsx
@@ -43,7 +43,7 @@ const UserMenu: React.FC<UserMenuProps> = props => {
   const history = useHistory();
   const { list, closeBtn, loader } = useStyles();
   const { isMenuVisible, onClose } = props;
-  const { data: AuthData } = useContext<AuthContextData>(AuthContext);
+  const { data: AuthData, logout } = useContext<AuthContextData>(AuthContext);
   const { userId, role } = AuthData;
 
   const getQueryByRole = (role: UserRole, id: string) => {
@@ -69,6 +69,7 @@ const UserMenu: React.FC<UserMenuProps> = props => {
     variables,
   });
   const user = data && data[role.toLowerCase()];
+
   return (
     <Drawer open={isMenuVisible} onClose={onClose} data-testid='slide-menu'>
       <Box className={list}>
@@ -97,6 +98,7 @@ const UserMenu: React.FC<UserMenuProps> = props => {
             <UserMenuSettings
               allowPushedNotifications={!!user.allowPushedNotifications}
               updatePushNotificationsSettings={() => {}}
+              onLogoutClick={() => logout()}
             />
           </Box>
         )}

--- a/src/components/UserMenuSettings/UserMenuSettings.tsx
+++ b/src/components/UserMenuSettings/UserMenuSettings.tsx
@@ -1,38 +1,55 @@
 import React from 'react';
-import { Box, makeStyles, Typography } from '@material-ui/core';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Switch from '@material-ui/core/Switch';
-import theme from 'styles/theme';
-import { UserMenuSettingsProps } from './types';
+import {
+  List,
+  ListSubheader,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  ListItemSecondaryAction,
+  Switch,
+} from '@material-ui/core';
 
-const useStyles = makeStyles({
-  wrapper: {
-    padding: theme.spacing(2),
-  },
-});
+import NotificationsIcon from '@material-ui/icons/Notifications';
+import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+import { UserMenuSettingsProps } from './types';
+import USER_MENU_SETTINGS_DICTIONARY from './userMenuSettings.dictionary';
 
 const UserMenuSettings: React.FC<UserMenuSettingsProps> = props => {
-  const PUSH_NOTIFICATIONS_LABEL = 'Allow push notifications';
-  const { allowPushedNotifications, updatePushNotificationsSettings } = props;
-  const { wrapper } = useStyles();
+  const {
+    allowPushedNotifications,
+    updatePushNotificationsSettings,
+    onLogoutClick,
+  } = props;
+
   return (
-    <Box className={wrapper}>
-      <Typography component='h3' variant='body1'>
-        <Box component='strong' fontWeight={'fontWeightBold'}>
-          Settings
-        </Box>
-      </Typography>
-      <FormControlLabel
-        control={
+    <List
+      subheader={
+        <ListSubheader>
+          <strong>{USER_MENU_SETTINGS_DICTIONARY.SETTINGS}</strong>
+        </ListSubheader>
+      }>
+      <ListItem>
+        <ListItemIcon>
+          <NotificationsIcon />
+        </ListItemIcon>
+        <ListItemText
+          primary={USER_MENU_SETTINGS_DICTIONARY.PUSH_NOTIFICATIONS_LABEL}
+        />
+        <ListItemSecondaryAction>
           <Switch
             checked={allowPushedNotifications}
             onChange={updatePushNotificationsSettings}
             disabled
           />
-        }
-        label={PUSH_NOTIFICATIONS_LABEL}
-      />
-    </Box>
+        </ListItemSecondaryAction>
+      </ListItem>
+      <ListItem button onClick={onLogoutClick}>
+        <ListItemIcon>
+          <ExitToAppIcon />
+        </ListItemIcon>
+        <ListItemText primary={USER_MENU_SETTINGS_DICTIONARY.LOGOUT} />
+      </ListItem>
+    </List>
   );
 };
 

--- a/src/components/UserMenuSettings/__tests__/UserMenuSettings.test.tsx
+++ b/src/components/UserMenuSettings/__tests__/UserMenuSettings.test.tsx
@@ -3,10 +3,18 @@ import { create } from 'react-test-renderer';
 
 import UserMenuSettings from 'components/UserMenuSettings';
 
-jest.mock('@material-ui/core/Box', () => 'Box');
-jest.mock('@material-ui/core/Typography', () => 'Typography');
-jest.mock('@material-ui/core/FormControlLabel', () => 'FormControlLabel');
+jest.mock('@material-ui/core/List', () => 'List');
+jest.mock('@material-ui/core/ListItem', () => 'ListItem');
+jest.mock('@material-ui/core/ListSubheader', () => 'ListSubheader');
+jest.mock('@material-ui/core/ListItemIcon', () => 'ListItemIcon');
+jest.mock('@material-ui/core/ListItemText', () => 'ListItemText');
 jest.mock('@material-ui/core/Switch', () => 'Switch');
+jest.mock(
+  '@material-ui/core/ListItemSecondaryAction',
+  () => 'ListItemSecondaryAction'
+);
+jest.mock('@material-ui/icons/Notifications', () => 'Notifications');
+jest.mock('@material-ui/icons/ExitToApp', () => 'ExitToAppIcon');
 
 describe('Component - UserMenuSettings', () => {
   test('renders correctly', () => {

--- a/src/components/UserMenuSettings/__tests__/__snapshots__/UserMenuSettings.test.tsx.snap
+++ b/src/components/UserMenuSettings/__tests__/__snapshots__/UserMenuSettings.test.tsx.snap
@@ -1,29 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component - UserMenuSettings renders correctly 1`] = `
-<Box
-  className="makeStyles-wrapper-1"
+<List
+  subheader={
+    <ListSubheader>
+      <strong>
+        Settings
+      </strong>
+    </ListSubheader>
+  }
 >
-  <Typography
-    component="h3"
-    variant="body1"
-  >
-    <Box
-      component="strong"
-      fontWeight="fontWeightBold"
-    >
-      Settings
-    </Box>
-  </Typography>
-  <FormControlLabel
-    control={
+  <ListItem>
+    <ListItemIcon>
+      <Notifications />
+    </ListItemIcon>
+    <ListItemText
+      primary="Allow push notifications"
+    />
+    <ListItemSecondaryAction>
       <Switch
         checked={true}
         disabled={true}
         onChange={[Function]}
       />
-    }
-    label="Allow push notifications"
-  />
-</Box>
+    </ListItemSecondaryAction>
+  </ListItem>
+  <ListItem
+    button={true}
+  >
+    <ListItemIcon>
+      <ExitToAppIcon />
+    </ListItemIcon>
+    <ListItemText
+      primary="Logout"
+    />
+  </ListItem>
+</List>
 `;

--- a/src/components/UserMenuSettings/types.ts
+++ b/src/components/UserMenuSettings/types.ts
@@ -1,4 +1,7 @@
 export type UserMenuSettingsProps = {
   allowPushedNotifications: boolean;
   updatePushNotificationsSettings: () => void;
+  onLogoutClick?:
+    | ((event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void)
+    | undefined;
 };

--- a/src/components/UserMenuSettings/userMenuSettings.dictionary.ts
+++ b/src/components/UserMenuSettings/userMenuSettings.dictionary.ts
@@ -1,0 +1,13 @@
+interface UserMenuSettingsDictionary {
+  SETTINGS: string;
+  PUSH_NOTIFICATIONS_LABEL: string;
+  LOGOUT: string;
+}
+
+const USER_MENU_SETTINGS_DICTIONARY: UserMenuSettingsDictionary = {
+  SETTINGS: 'Settings',
+  PUSH_NOTIFICATIONS_LABEL: 'Allow push notifications',
+  LOGOUT: 'Logout',
+};
+
+export default USER_MENU_SETTINGS_DICTIONARY;


### PR DESCRIPTION
# [BUD-50](https://digitalrig.atlassian.net/browse/BUD-50) Logout

## Description

Logout functionality added to left menu.
After clicking button the user is successfully logout from the app.

## Checklist

- [x] Added Logout Button to left menu.

# Screenshots 

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/12997200/70063555-4a37fa80-15e8-11ea-9852-66652db4eca1.gif)

