### PR TITLE
[BUD-232] Bug - Header & TasksList bugs

### DIFF
--- a/src/components/AppWrapper/AppWrapper.tsx
+++ b/src/components/AppWrapper/AppWrapper.tsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
       flexDirection: 'column',
       minHeight: '100vh',
+      height: '100%',
     },
     drawerPaper: {
       width: drawerWidth,

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -18,12 +18,13 @@ import {
   MenuTypes,
 } from './types';
 
+const LOADER_SIZE = 0.25;
+
+const SHADOW_SIZE = 0.5;
+
 const useStyles = makeStyles<Theme>(theme => ({
   menuButton: {
     marginRight: theme.spacing(2),
-  },
-  appBar: {
-    zIndex: theme.zIndex.drawer + 1,
   },
   withoutShadow: {
     boxShadow: 'none',
@@ -47,7 +48,7 @@ const useStyles = makeStyles<Theme>(theme => ({
   },
   loaderLayer: {
     width: '110%',
-    height: '100%',
+    height: `calc(100% - ${theme.spacing(SHADOW_SIZE)})`,
     left: '-5%',
     top: 0,
     position: 'absolute',
@@ -57,13 +58,14 @@ const useStyles = makeStyles<Theme>(theme => ({
     visibility: 'hidden',
   },
   appBarContainer: {
+    overflow: 'hidden',
     width: '100%',
     position: 'sticky',
     top: 0,
     right: 0,
     left: 'auto',
     zIndex: theme.zIndex.appBar,
-    paddingBottom: theme.spacing(0.5),
+    paddingBottom: theme.spacing(LOADER_SIZE + SHADOW_SIZE),
   },
 }));
 
@@ -77,7 +79,6 @@ const Header: React.FC<HeaderProps> = ({
 }) => {
   const {
     menuButton,
-    appBar,
     withoutShadow,
     defaultBackground,
     paperBackground,
@@ -107,15 +108,14 @@ const Header: React.FC<HeaderProps> = ({
     [MenuShapes.ROUNDED]: [roundedBackground, roundedShape],
   };
 
-  const HeaderBar = () => (
-    <>
+  return (
+    <Box className={appBarContainer}>
       <AppBar
-        component={'header'}
-        className={clsx(appBar, colorClassNames[color], shapeClassNames[shape], {
+        className={clsx(colorClassNames[color], shapeClassNames[shape], {
           [withoutShadow]: loading || !scrollTrigger,
         })}
-        position={'sticky'}
-        color={'inherit'}>
+        position='static'
+        color='inherit'>
         <Toolbar>
           <IconButton
             edge='start'
@@ -135,15 +135,7 @@ const Header: React.FC<HeaderProps> = ({
           [loaderLayer]: children,
         })}
       />
-    </>
-  );
-
-  return children ? (
-    <Box className={appBarContainer}>
-      <HeaderBar />
     </Box>
-  ) : (
-    <HeaderBar />
   );
 };
 

--- a/src/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -1,12 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component - Header should render Header with color paper 1`] = `
-Array [
+<Box
+  className="makeStyles-appBarContainer-10"
+>
   <AppBar
-    className="makeStyles-appBar-2 makeStyles-paperBackground-5 makeStyles-withoutShadow-3"
+    className="makeStyles-paperBackground-4 makeStyles-withoutShadow-2"
     color="inherit"
-    component="header"
-    position="sticky"
+    position="static"
   >
     <Toolbar>
       <IconButton
@@ -17,21 +18,22 @@ Array [
         <MenuIcon />
       </IconButton>
     </Toolbar>
-  </AppBar>,
+  </AppBar>
   <LinearProgress
-    className="makeStyles-loaderShadow-8 makeStyles-hideLoader-10"
+    className="makeStyles-loaderShadow-7 makeStyles-hideLoader-9"
     variant="indeterminate"
-  />,
-]
+  />
+</Box>
 `;
 
 exports[`Component - Header should render Header with type back 1`] = `
-Array [
+<Box
+  className="makeStyles-appBarContainer-10"
+>
   <AppBar
-    className="makeStyles-appBar-2 makeStyles-defaultBackground-4 makeStyles-withoutShadow-3"
+    className="makeStyles-defaultBackground-3 makeStyles-withoutShadow-2"
     color="inherit"
-    component="header"
-    position="sticky"
+    position="static"
   >
     <Toolbar>
       <IconButton
@@ -42,21 +44,22 @@ Array [
         <ArrowBackIcon />
       </IconButton>
     </Toolbar>
-  </AppBar>,
+  </AppBar>
   <LinearProgress
-    className="makeStyles-loaderShadow-8 makeStyles-hideLoader-10"
+    className="makeStyles-loaderShadow-7 makeStyles-hideLoader-9"
     variant="indeterminate"
-  />,
-]
+  />
+</Box>
 `;
 
 exports[`Component - Header should render Header with type menu 1`] = `
-Array [
+<Box
+  className="makeStyles-appBarContainer-10"
+>
   <AppBar
-    className="makeStyles-appBar-2 makeStyles-defaultBackground-4 makeStyles-withoutShadow-3"
+    className="makeStyles-defaultBackground-3 makeStyles-withoutShadow-2"
     color="inherit"
-    component="header"
-    position="sticky"
+    position="static"
   >
     <Toolbar>
       <IconButton
@@ -67,10 +70,10 @@ Array [
         <MenuIcon />
       </IconButton>
     </Toolbar>
-  </AppBar>,
+  </AppBar>
   <LinearProgress
-    className="makeStyles-loaderShadow-8 makeStyles-hideLoader-10"
+    className="makeStyles-loaderShadow-7 makeStyles-hideLoader-9"
     variant="indeterminate"
-  />,
-]
+  />
+</Box>
 `;

--- a/src/components/NewbieGrid/NewbieGrid.tsx
+++ b/src/components/NewbieGrid/NewbieGrid.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles<Theme>(theme => ({
     boxShadow: theme.shadows[5],
     '&:hover': {
       boxShadow: theme.shadows[7],
-      transform: 'rotate(0deg) scale(1.1)',
+      transform: 'rotate(0deg) scale(1.05)',
     },
   },
   cardInfo: {


### PR DESCRIPTION
# [#232](https://digitalrig.atlassian.net/browse/BUD-232) Bug / Header + empty task list bugs

## Description

Current PR should fix the bugs noticed below;

## Checklist

1. [X] Header layout takes more width than 100%; 
2. [X] Header on task details screen doesn't keep loader while scrolling; 
3. [X] Empty task list message isn't centered;

# Screenshots

1.
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/5225448/71546221-05a84080-2995-11ea-8359-44e2883109b5.gif)


2.
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/5225448/71546222-080a9a80-2995-11ea-94e7-d4598f38a529.gif)


3.
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/5225448/71546224-0b058b00-2995-11ea-8ab3-5b51c83aee06.gif)


