### PR TITLE
[BUD-316] Add newbie details routes

### DIFF
--- a/src/components/AuthenticatedApp/AuthenticatedApp.tsx
+++ b/src/components/AuthenticatedApp/AuthenticatedApp.tsx
@@ -17,6 +17,10 @@ import { SnackbarProvider } from 'contexts/SnackbarContext';
 
 const newbieRoutes = [
   {
+    path: ROUTES.NEWBIE_DETAILS,
+    component: ContactDetails,
+  },
+  {
     path: ROUTES.NEWBIE_BUDDY_DETAILS,
     component: ContactDetails,
   },
@@ -50,6 +54,10 @@ const buddyRoutes = [
   {
     path: ROUTES.BUDDY_TASK_DETAILS,
     component: TaskDetails,
+  },
+  {
+    path: ROUTES.BUDDY_DETAILS,
+    component: ContactDetails,
   },
   {
     path: ROUTES.BUDDY_NEWBIE_DETAILS,

--- a/src/components/AvatarHeader/AvatarHeader.tsx
+++ b/src/components/AvatarHeader/AvatarHeader.tsx
@@ -6,8 +6,9 @@ import { Theme } from '@material-ui/core/';
 import Box from '@material-ui/core/Box';
 import { useQuery } from '@apollo/react-hooks';
 import Avatar from 'components/Avatar';
+import { useAuth } from 'contexts/AuthContext';
 import { AVATAR_HEADER } from 'graphql/avatar-header.graphql';
-import { Query, QueryNewbieArgs } from 'buddy-app-schema';
+import { Query, QueryNewbieArgs, UserRole } from 'buddy-app-schema';
 import { getProgressInPercentages } from 'utils';
 import { ROUTES } from 'shared/routes';
 import { AvatarHeaderProps } from './types';
@@ -23,16 +24,24 @@ const useStyles = makeStyles<Theme>(theme => ({
 }));
 
 const AvatarHeader: React.FC<AvatarHeaderProps> = ({ newbieId, taskProgress }) => {
+  const [
+    {
+      data: { role },
+    },
+  ] = useAuth();
   const history = useHistory();
   const { background } = useStyles();
+
+  const routes = {
+    [UserRole.Buddy]: ROUTES.BUDDY_NEWBIE_DETAILS.replace(':newbieId', newbieId),
+    [UserRole.Newbie]: ROUTES.NEWBIE_DETAILS,
+  };
 
   const { loading, data } = useQuery<Query, QueryNewbieArgs>(AVATAR_HEADER, {
     variables: { newbieId },
   });
 
-  const handleClick = () => {
-    history.push(ROUTES.BUDDY_NEWBIE_DETAILS.replace(':newbieId', newbieId));
-  };
+  const handleClick = () => history.push(routes[role]);
 
   return (
     <Box className={background} data-testid='avatar-header'>

--- a/src/components/AvatarHeader/__tests__/AvatarHeader.test.tsx
+++ b/src/components/AvatarHeader/__tests__/AvatarHeader.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { act, create, ReactTestRenderer } from 'react-test-renderer';
-
+import { AuthProvider } from 'contexts/AuthContext';
 import AvatarHeader from 'components/AvatarHeader';
 import { MockedProvider } from '@apollo/react-testing';
 import { MemoryRouter, Route } from 'react-router';
 import waitForExpect from 'wait-for-expect';
-import { NewbieAvatarDetails } from '__mocks__';
+import { NewbieAvatarDetails, mockedBuddyContext } from '__mocks__';
 
 jest.mock('@material-ui/core/Box', () => 'Box');
 jest.mock('@material-ui/core/CircularProgress', () => 'CircularProgress');
@@ -22,7 +22,9 @@ describe('Component - AvatarHeader', () => {
         addTypename={false}>
         <MemoryRouter initialEntries={[path]}>
           <Route path={'/buddy/newbies/:newbieId/tasks'}>
-            <AvatarHeader newbieId='1234' taskProgress={0.54} />
+            <AuthProvider value={mockedBuddyContext()}>
+              <AvatarHeader newbieId='1234' taskProgress={0.54} />
+            </AuthProvider>
           </Route>
         </MemoryRouter>
       </MockedProvider>

--- a/src/components/ContactDetails/ContactDetails.tsx
+++ b/src/components/ContactDetails/ContactDetails.tsx
@@ -19,43 +19,43 @@ import { ContactDetailsProps } from './types';
 const ContactDetails: React.FC<ContactDetailsProps> = ({ history }) => {
   const { newbieId } = useParams<QueryNewbieArgs>();
   const { buddyId } = useParams<QueryBuddyArgs>();
+  const isCurrentUserDetails = !newbieId && !buddyId;
   const [
     {
       data: { role, userId },
     },
   ] = useAuth();
 
-  const queryByRole =
-    newbieId || buddyId
-      ? {
-          [UserRole.Newbie]: {
-            query: BUDDY_CONTACT_DETAILS,
-            variables: { buddyId },
-            userRole: UserRole.Buddy.toLowerCase(),
-            onBackClick: () => history.push(ROUTES.NEWBIE_TASKS_LIST),
-          },
-          [UserRole.Buddy]: {
-            query: NEWBIE_CONTACT_DETAILS,
-            variables: { newbieId },
-            userRole: UserRole.Newbie.toLowerCase(),
-            onBackClick: () =>
-              history.push(ROUTES.BUDDY_TASKS_LIST.replace(':newbieId', newbieId)),
-          },
-        }
-      : {
-          [UserRole.Newbie]: {
-            query: NEWBIE_CONTACT_DETAILS,
-            variables: { newbieId: userId },
-            userRole: UserRole.Newbie.toLowerCase(),
-            onBackClick: () => history.push(ROUTES.NEWBIE_TASKS_LIST),
-          },
-          [UserRole.Buddy]: {
-            query: BUDDY_CONTACT_DETAILS,
-            variables: { buddyId: userId },
-            userRole: UserRole.Buddy.toLowerCase(),
-            onBackClick: () => history.push(ROUTES.BUDDY_SELECT_NEWBIE),
-          },
-        };
+  const queryByRole = isCurrentUserDetails
+    ? {
+        [UserRole.Newbie]: {
+          query: NEWBIE_CONTACT_DETAILS,
+          variables: { newbieId: userId },
+          userRole: UserRole.Newbie.toLowerCase(),
+          onBackClick: () => history.push(ROUTES.NEWBIE_TASKS_LIST),
+        },
+        [UserRole.Buddy]: {
+          query: BUDDY_CONTACT_DETAILS,
+          variables: { buddyId: userId },
+          userRole: UserRole.Buddy.toLowerCase(),
+          onBackClick: () => history.push(ROUTES.BUDDY_SELECT_NEWBIE),
+        },
+      }
+    : {
+        [UserRole.Newbie]: {
+          query: BUDDY_CONTACT_DETAILS,
+          variables: { buddyId },
+          userRole: UserRole.Buddy.toLowerCase(),
+          onBackClick: () => history.push(ROUTES.NEWBIE_TASKS_LIST),
+        },
+        [UserRole.Buddy]: {
+          query: NEWBIE_CONTACT_DETAILS,
+          variables: { newbieId },
+          userRole: UserRole.Newbie.toLowerCase(),
+          onBackClick: () =>
+            history.push(ROUTES.BUDDY_TASKS_LIST.replace(':newbieId', newbieId)),
+        },
+      };
 
   const { query, variables, userRole, onBackClick } = queryByRole[role];
   const { data, loading } = useQuery<UserBasicDetails, BasicDetailsParams>(query, {

--- a/src/components/ContactDetails/ContactDetails.tsx
+++ b/src/components/ContactDetails/ContactDetails.tsx
@@ -21,25 +21,42 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ history }) => {
   const { buddyId } = useParams<QueryBuddyArgs>();
   const [
     {
-      data: { role },
+      data: { role, userId },
     },
   ] = useAuth();
 
-  const queryByRole = {
-    [UserRole.Newbie]: {
-      query: BUDDY_CONTACT_DETAILS,
-      variables: { buddyId },
-      userRole: UserRole.Buddy.toLowerCase(),
-      onBackClick: () => history.push(ROUTES.NEWBIE_TASKS_LIST),
-    },
-    [UserRole.Buddy]: {
-      query: NEWBIE_CONTACT_DETAILS,
-      variables: { newbieId },
-      userRole: UserRole.Newbie.toLowerCase(),
-      onBackClick: () =>
-        history.push(ROUTES.BUDDY_TASKS_LIST.replace(':newbieId', newbieId)),
-    },
-  };
+  const queryByRole =
+    newbieId || buddyId
+      ? {
+          [UserRole.Newbie]: {
+            query: BUDDY_CONTACT_DETAILS,
+            variables: { buddyId },
+            userRole: UserRole.Buddy.toLowerCase(),
+            onBackClick: () => history.push(ROUTES.NEWBIE_TASKS_LIST),
+          },
+          [UserRole.Buddy]: {
+            query: NEWBIE_CONTACT_DETAILS,
+            variables: { newbieId },
+            userRole: UserRole.Newbie.toLowerCase(),
+            onBackClick: () =>
+              history.push(ROUTES.BUDDY_TASKS_LIST.replace(':newbieId', newbieId)),
+          },
+        }
+      : {
+          [UserRole.Newbie]: {
+            query: NEWBIE_CONTACT_DETAILS,
+            variables: { newbieId: userId },
+            userRole: UserRole.Newbie.toLowerCase(),
+            onBackClick: () => history.push(ROUTES.NEWBIE_TASKS_LIST),
+          },
+          [UserRole.Buddy]: {
+            query: BUDDY_CONTACT_DETAILS,
+            variables: { buddyId: userId },
+            userRole: UserRole.Buddy.toLowerCase(),
+            onBackClick: () => history.push(ROUTES.BUDDY_SELECT_NEWBIE),
+          },
+        };
+
   const { query, variables, userRole, onBackClick } = queryByRole[role];
   const { data, loading } = useQuery<UserBasicDetails, BasicDetailsParams>(query, {
     variables,

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -20,6 +20,9 @@ const useStyles = makeStyles(theme => ({
     minHeight: '10rem',
     marginTop: theme.spacing(3),
   },
+  form: {
+    width: '100%',
+  },
   submit: {
     margin: theme.spacing(3, 0),
   },
@@ -75,7 +78,11 @@ const Login: React.FC = () => {
         {DICTIONARY.TITLE}
       </Typography>
       <SpaceManLogo className={classes.spaceMan} />
-      <form data-testid='form' noValidate onSubmit={handleSubmit(onSubmit)}>
+      <form
+        className={classes.form}
+        data-testid='form'
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}>
         <TextField
           inputProps={{ 'data-testid': 'email' }}
           inputRef={register({

--- a/src/components/UserMenu/UserMenu.tsx
+++ b/src/components/UserMenu/UserMenu.tsx
@@ -41,6 +41,11 @@ const UserMenu: React.FC<UserMenuProps> = ({ onCloseClick }) => {
     dispatch,
   ] = useAuth();
 
+  const userDetailsRoutes = {
+    [UserRole.Buddy]: ROUTES.BUDDY_DETAILS,
+    [UserRole.Newbie]: ROUTES.NEWBIE_DETAILS,
+  };
+
   const onLogoutClick = () => {
     logout(dispatch);
     history.push(ROUTES.BASE);
@@ -64,6 +69,11 @@ const UserMenu: React.FC<UserMenuProps> = ({ onCloseClick }) => {
     onCloseClick && onCloseClick();
   };
 
+  const userClickHandler = () => {
+    history.push(userDetailsRoutes[role]);
+    onCloseClick && onCloseClick();
+  };
+
   const { query, variables } = getQueryByRole(role, userId) || {};
   const { data, loading } = useQuery<UserBasicDetails, BasicDetailsParams>(query, {
     variables,
@@ -74,7 +84,7 @@ const UserMenu: React.FC<UserMenuProps> = ({ onCloseClick }) => {
     <Box className={list}>
       {user && (
         <Box data-testid='slide-menu-body'>
-          <UserMenuDetails user={user} />
+          <UserMenuDetails user={user} onClick={userClickHandler} />
           <Divider />
           {isBuddy(role) && (
             <UserMenuNewbies

--- a/src/components/UserMenuDetails/UserMenuDetails.tsx
+++ b/src/components/UserMenuDetails/UserMenuDetails.tsx
@@ -19,13 +19,13 @@ const useStyles = makeStyles({
   },
 });
 
-const UserMenuDetails: React.FC<UserMenuDetailsProps> = props => {
-  const { user } = props;
+const UserMenuDetails: React.FC<UserMenuDetailsProps> = ({ user, onClick }) => {
   const classes = useStyles();
+
   return (
     <Box className={classes.wrapper}>
       <Box className={classes.avatar}>
-        <Avatar imgSrc={user && user.photo} />
+        <Avatar imgSrc={user && user.photo} onClick={onClick} />
       </Box>
       <Typography component='p' variant='body1'>
         <Box component='strong' fontWeight={'fontWeightBold'}>

--- a/src/components/UserMenuDetails/types.ts
+++ b/src/components/UserMenuDetails/types.ts
@@ -2,4 +2,5 @@ import { Buddy, Newbie } from 'buddy-app-schema';
 
 export type UserMenuDetailsProps = {
   user: Partial<Newbie> | Partial<Buddy>;
+  onClick?: () => void;
 };

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -3,6 +3,7 @@ enum ROUTES {
   LOGIN = '/login',
   ROUTE_404 = '/404',
   BUDDY = '/buddy/',
+  BUDDY_DETAILS = '/buddy/details',
   BUDDY_ADD_TASK = '/buddy/newbies/:newbieId/add-task',
   BUDDY_TASK_DETAILS = '/buddy/newbies/:newbieId/tasks/:taskId',
   BUDDY_TASKS_LIST = '/buddy/newbies/:newbieId/tasks',
@@ -10,8 +11,9 @@ enum ROUTES {
   BUDDY_ADD_NEWBIE = '/buddy/add-newbie',
   BUDDY_NEWBIE_DETAILS = '/buddy/newbies/:newbieId/details',
   NEWBIE = '/newbie',
-  NEWBIE_TASK_DETAILS = '/newbie/tasks/:taskId',
+  NEWBIE_DETAILS = '/newbie/details',
   NEWBIE_TASKS_LIST = '/newbie/tasks',
+  NEWBIE_TASK_DETAILS = '/newbie/tasks/:taskId',
   NEWBIE_BUDDY_DETAILS = '/newbie/buddy/:buddyId/details',
 }
 


### PR DESCRIPTION
# [[BUD-316] Bug / Clicking on avatar takes user to 404 (when logged in as a newbie) ](https://digitalrig.atlassian.net/browse/BUD-316)

## Description

1.  Add user details routes:

  - `/newbie/details`;
  - `/buddy/details`;

2. Add `onClick` action for user avatar in menu;

## Screenshots

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/5225448/74753910-2001ea80-5271-11ea-9b14-e7585d307706.gif)
