### PR TITLE
[BUD-309] [BUD-319] [BUD-320] Bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   - yarn cy:ci
   - yarn build
   - yarn lighthouse
+  - cd ../../
 after_success:
   - codecov --token="$CODECOV_TOKEN"
 notifications:

--- a/packages/client/src/components/Login/Login.tsx
+++ b/packages/client/src/components/Login/Login.tsx
@@ -51,6 +51,9 @@ const Login: React.FC = () => {
     current: { showDialog },
   } = useRef(useDialog());
 
+  const onFormChange = (e: React.ChangeEvent<HTMLFormElement>) =>
+    (e.target.value = e.target.value.trim());
+
   const onSubmit = ({ email, password }: FormData) =>
     login(dispatch, email, password);
 
@@ -82,6 +85,7 @@ const Login: React.FC = () => {
         className={classes.form}
         data-testid='form'
         noValidate
+        onChange={onFormChange}
         onSubmit={handleSubmit(onSubmit)}>
         <TextField
           inputProps={{ 'data-testid': 'email' }}

--- a/packages/client/src/components/TasksList/__tests__/__snapshots__/TasksList.test.tsx.snap
+++ b/packages/client/src/components/TasksList/__tests__/__snapshots__/TasksList.test.tsx.snap
@@ -19,7 +19,7 @@ Array [
       variant="fullWidth"
     >
       <Tab
-        label="Newbie Tasks"
+        label="Newbie tasks"
       />
       <Tab
         label="My tasks"
@@ -98,7 +98,7 @@ Array [
       variant="fullWidth"
     >
       <Tab
-        label="Newbie Tasks"
+        label="Newbie tasks"
       />
       <Tab
         label="My tasks"
@@ -209,7 +209,7 @@ Array [
       variant="fullWidth"
     >
       <Tab
-        label="Newbie Tasks"
+        label="Newbie tasks"
       />
       <Tab
         label="My tasks"

--- a/packages/client/src/components/TasksList/dictionary.ts
+++ b/packages/client/src/components/TasksList/dictionary.ts
@@ -8,7 +8,7 @@ interface TaskListDictionary {
 
 const TASK_LIST_DICTIONARY: TaskListDictionary = {
   BUDDY_TAB_TITLE: 'My tasks',
-  NEWBIE_TAB_TITLE: 'Newbie Tasks',
+  NEWBIE_TAB_TITLE: 'Newbie tasks',
   SUCCESS_MESSAGE: 'Task status updated',
   ERROR_MESSAGE: 'An error ocurred updating task',
   PLUS_BUTTON_TITLE: 'Add new task',

--- a/packages/client/src/components/UserDetails/UserDetails.tsx
+++ b/packages/client/src/components/UserDetails/UserDetails.tsx
@@ -8,7 +8,8 @@ import Typography from '@material-ui/core/Typography';
 import Avatar from 'components/Avatar';
 import { isNewbie } from 'utils';
 import { UserRole } from '@buddy-app/schema';
-import { UserDetailsProps } from './types';
+import { UserDetailsProps, ContactDetail } from './types';
+import DICTIONARY from './dictionary';
 
 const useStyles = makeStyles(theme => ({
   notesTextarea: {
@@ -49,52 +50,66 @@ const UserDetails: React.FC<UserDetailsProps> = props => {
 
   const isNotesVisible = (role: UserRole) => isNewbie(role);
 
+  const contactDetails: ContactDetail[] = [
+    {
+      title: DICTIONARY.NAME,
+      value: name,
+      visible: !!name,
+      testId: 'contact-name',
+    },
+    {
+      title: DICTIONARY.POSITION,
+      value: position,
+      visible: !!position,
+      testId: 'contact-position',
+    },
+    {
+      title: DICTIONARY.START_DATE,
+      value: new Date(startDate).toLocaleDateString(),
+      visible: !!startDate,
+      testId: 'contact-start-date',
+    },
+    {
+      title: DICTIONARY.EMAIL,
+      value: (
+        <Link href={`mailto:${email}`} component='a'>
+          {email}
+        </Link>
+      ),
+      visible: !!email,
+      testId: 'contact-email',
+    },
+    {
+      title: DICTIONARY.PHONE,
+      value: phoneNumber,
+      visible: !!phoneNumber,
+      testId: 'contact-phone',
+    },
+  ];
+
   return (
     <Box className={wrapper} data-testid='contact-details-page'>
       <Box className={avatar}>
         <Avatar imgSrc={photo} />
       </Box>
       <Box>
-        <Typography component='p' className={label}>
-          Name
-        </Typography>
+        {contactDetails.map(
+          ({ title, value, visible, testId }) =>
+            visible && (
+              <React.Fragment key={testId}>
+                <Typography component='p' className={label}>
+                  {title}
+                </Typography>
 
-        <Typography component='p' data-testid='contact-name' className={detailText}>
-          {name}
-        </Typography>
-
-        <Typography component='p' className={label}>
-          What I do
-        </Typography>
-
-        <Typography component='p' className={detailText}>
-          {position}
-        </Typography>
-
-        <Typography component='p' className={label}>
-          Start date
-        </Typography>
-
-        <Typography component='p' className={detailText}>
-          {startDate}
-        </Typography>
-
-        <Typography component='p' className={label}>
-          E-mail
-        </Typography>
-        <Typography component='p' className={detailText}>
-          <Link href={`mailto:${email}`} component={'a'}>
-            {email}
-          </Link>
-        </Typography>
-
-        <Typography component='p' className={label}>
-          Phone
-        </Typography>
-
-        <Typography component='p' className={detailText}>
-          {phoneNumber}
-        </Typography>
+                <Typography
+                  component='p'
+                  data-testid={testId}
+                  className={detailText}>
+                  {value}
+                </Typography>
+              </React.Fragment>
+            )
+        )}
         {isNotesVisible(role as UserRole) && (
           <>
             <Typography component='p' className={label}>

--- a/packages/client/src/components/UserDetails/__tests__/__snapshots__/UserDetails.test.tsx.snap
+++ b/packages/client/src/components/UserDetails/__tests__/__snapshots__/UserDetails.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`Component - UserDetails when logged in as buddy renders correctly 1`] =
     <Typography
       className="makeStyles-detailText-5"
       component="p"
+      data-testid="contact-position"
     >
       Dev Ops
     </Typography>
@@ -47,8 +48,9 @@ exports[`Component - UserDetails when logged in as buddy renders correctly 1`] =
     <Typography
       className="makeStyles-detailText-5"
       component="p"
+      data-testid="contact-start-date"
     >
-      2010-01-01
+      1/1/2010
     </Typography>
     <Typography
       className="makeStyles-label-4"
@@ -59,6 +61,7 @@ exports[`Component - UserDetails when logged in as buddy renders correctly 1`] =
     <Typography
       className="makeStyles-detailText-5"
       component="p"
+      data-testid="contact-email"
     >
       <Link
         component="a"
@@ -76,6 +79,7 @@ exports[`Component - UserDetails when logged in as buddy renders correctly 1`] =
     <Typography
       className="makeStyles-detailText-5"
       component="p"
+      data-testid="contact-phone"
     >
       1234567
     </Typography>
@@ -128,6 +132,7 @@ exports[`Component - UserDetails when logged in as newbie renders correctly 1`] 
     <Typography
       className="makeStyles-detailText-5"
       component="p"
+      data-testid="contact-position"
     >
       Dev Ops
     </Typography>
@@ -140,8 +145,9 @@ exports[`Component - UserDetails when logged in as newbie renders correctly 1`] 
     <Typography
       className="makeStyles-detailText-5"
       component="p"
+      data-testid="contact-start-date"
     >
-      2010-01-01
+      1/1/2010
     </Typography>
     <Typography
       className="makeStyles-label-4"
@@ -152,6 +158,7 @@ exports[`Component - UserDetails when logged in as newbie renders correctly 1`] 
     <Typography
       className="makeStyles-detailText-5"
       component="p"
+      data-testid="contact-email"
     >
       <Link
         component="a"
@@ -169,6 +176,7 @@ exports[`Component - UserDetails when logged in as newbie renders correctly 1`] 
     <Typography
       className="makeStyles-detailText-5"
       component="p"
+      data-testid="contact-phone"
     >
       1234567
     </Typography>

--- a/packages/client/src/components/UserDetails/dictionary.ts
+++ b/packages/client/src/components/UserDetails/dictionary.ts
@@ -1,0 +1,17 @@
+interface UserDetailsDictionary {
+  NAME: string;
+  POSITION: string;
+  START_DATE: string;
+  EMAIL: string;
+  PHONE: string;
+}
+
+const USER_DETAILS_DICTIONARY: UserDetailsDictionary = {
+  NAME: 'Name',
+  POSITION: 'What I do',
+  START_DATE: 'Start date',
+  EMAIL: 'E-mail',
+  PHONE: 'Phone',
+};
+
+export default USER_DETAILS_DICTIONARY;

--- a/packages/client/src/components/UserDetails/types.ts
+++ b/packages/client/src/components/UserDetails/types.ts
@@ -3,3 +3,10 @@ import { Buddy, Newbie } from '@buddy-app/schema';
 export type UserDetailsProps = {
   details: Partial<Newbie> | (Partial<Buddy> & { notes?: string });
 };
+
+export interface ContactDetail {
+  title: string;
+  value: JSX.Element | string;
+  visible: boolean;
+  testId: string;
+}

--- a/packages/services/.gitignore
+++ b/packages/services/.gitignore
@@ -1,3 +1,4 @@
+.env*
 # package directories
 node_modules
 jspm_packages


### PR DESCRIPTION
# [[BUD-309] Bug / Typo on tab label ](https://digitalrig.atlassian.net/browse/BUD-309)
# [[BUD-319] Bug / Starting date format ](https://digitalrig.atlassian.net/browse/BUD-319)
# [[BUD-320] Bug / Login email whitespace ](https://digitalrig.atlassian.net/browse/BUD-320)

## Description

1. Fixed typo on tab label;
2. Fixed starting date format;
3. Fixed login form whitespaces;

## Screenshots 

1. 

![Screenshot 2020-02-19 at 16 03 01](https://user-images.githubusercontent.com/5225448/74847131-ee048d00-5331-11ea-95bd-2e4bdb03ee27.png)

2.

![Screenshot 2020-02-19 at 16 05 25](https://user-images.githubusercontent.com/5225448/74847253-1d1afe80-5332-11ea-95fb-b4aa50e4a2a3.png)

3.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/5225448/74847272-24daa300-5332-11ea-9dc3-39ff466c05b6.gif)
